### PR TITLE
Fix for new packages

### DIFF
--- a/package.h
+++ b/package.h
@@ -12,6 +12,7 @@
 #include <bcrypt.h>
 #include <set>
 #include "helpers.h"
+#include <regex>
 
 struct PkgHeader
 {


### PR DESCRIPTION
In the latest update the package patches are no longer single digit. This pr uses regex to parse the file names and extract the patch number.